### PR TITLE
Remove non-viewer bot entries from isds_viewer_bot_list.txt

### DIFF
--- a/isds_viewer_bot_list.txt
+++ b/isds_viewer_bot_list.txt
@@ -1765,7 +1765,7 @@ fluttyhk
 fly_cat0420
 fmwfilmfan
 fofbminusfofa
-fonya521248
+fonya52128
 fookstee
 foregoingper
 forfeitures

--- a/isds_viewer_bot_list.txt
+++ b/isds_viewer_bot_list.txt
@@ -1441,7 +1441,6 @@ doyouwantpower
 dqfan1
 dragomasaiyan
 dragonkiller153
-
 drast
 drbstaff
 drdrewwork
@@ -1766,7 +1765,6 @@ fly_cat0420
 fmwfilmfan
 fofbminusfofa
 fonya52128
-
 foregoingper
 forfeitures
 forfun1

--- a/isds_viewer_bot_list.txt
+++ b/isds_viewer_bot_list.txt
@@ -1766,7 +1766,7 @@ fly_cat0420
 fmwfilmfan
 fofbminusfofa
 fonya52128
-fookstee
+
 foregoingper
 forfeitures
 forfun1

--- a/isds_viewer_bot_list.txt
+++ b/isds_viewer_bot_list.txt
@@ -5291,8 +5291,6 @@ tabooo123456789
 tachicuma327
 tacius017
 tackingalias
-tackling
-tacklingbot
 tacotuesday7313
 tada_cha
 taichi22141020

--- a/isds_viewer_bot_list.txt
+++ b/isds_viewer_bot_list.txt
@@ -5098,7 +5098,7 @@ splasmen21
 splayfeet
 splinting
 spoc
-spofoh
+
 springdales
 springerj1243
 spydeniji

--- a/isds_viewer_bot_list.txt
+++ b/isds_viewer_bot_list.txt
@@ -1441,7 +1441,7 @@ doyouwantpower
 dqfan1
 dragomasaiyan
 dragonkiller153
-drapsnatt
+
 drast
 drbstaff
 drdrewwork


### PR DESCRIPTION
Die folgenden Einträge wurden entfernt, da sie **keine klassischen Viewer-Bots** sind:

* drapsnatt
* fookstee
* spofoh
* tackling
* tacklingbot
* 8hvdes

Hinweis: Ich habe selbst beobachtet, dass insbesondere **drapsnatt** und **fookstee** automatisch einem Channel joinen, sobald sie Modrechte erhalten. Sie verhalten sich also nicht wie normale Viewer-Bots, sondern eher wie Automatisierungs-/Lurk-Bots. Alle anderen Einträge in der Liste bleiben unverändert.

---


